### PR TITLE
Made statusbar hover items readable

### DIFF
--- a/db/templates/vscode/dark.ejs
+++ b/db/templates/vscode/dark.ejs
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#<%- base["A1"]["hex"] %>",
     "statusBarItem.prominentHoverBackground": "#<%- base["A1"]["hex"] %>",
     "statusBarItem.activeBackground": "#<%- base["A4"]["hex"] %>",
-    "statusBarItem.hoverBackground": "#<%- base["A4"]["hex"] %>",
+    "statusBarItem.hoverBackground": "#<%- base["A1"]["hex"] %>",
     "titleBar.activeBackground": "#<%- base["A0"]["hex"] %>",
     "titleBar.activeForeground": "#<%- base["B6"]["hex"] %>",
     "titleBar.inactiveBackground": "#<%- base["AA"]["hex"] %>",

--- a/themes/Base2Tone_CaveDark-color-theme.json
+++ b/themes/Base2Tone_CaveDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#2f2d2e",
     "statusBarItem.prominentHoverBackground": "#2f2d2e",
     "statusBarItem.activeBackground": "#706b6d",
-    "statusBarItem.hoverBackground": "#706b6d",
+    "statusBarItem.hoverBackground": "#2f2d2e",
     "titleBar.activeBackground": "#222021",
     "titleBar.activeForeground": "#f0a8c1",
     "titleBar.inactiveBackground": "#151414",

--- a/themes/Base2Tone_DesertDark-color-theme.json
+++ b/themes/Base2Tone_DesertDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#3d3a34",
     "statusBarItem.prominentHoverBackground": "#3d3a34",
     "statusBarItem.activeBackground": "#908774",
-    "statusBarItem.hoverBackground": "#908774",
+    "statusBarItem.hoverBackground": "#3d3a34",
     "titleBar.activeBackground": "#292724",
     "titleBar.activeForeground": "#ddcba6",
     "titleBar.inactiveBackground": "#1b1a18",

--- a/themes/Base2Tone_DrawbridgeDark-color-theme.json
+++ b/themes/Base2Tone_DrawbridgeDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#252a41",
     "statusBarItem.prominentHoverBackground": "#252a41",
     "statusBarItem.activeBackground": "#5e6587",
-    "statusBarItem.hoverBackground": "#5e6587",
+    "statusBarItem.hoverBackground": "#252a41",
     "titleBar.activeBackground": "#1b1f32",
     "titleBar.activeForeground": "#c3cdfe",
     "titleBar.inactiveBackground": "#131520",

--- a/themes/Base2Tone_EarthDark-color-theme.json
+++ b/themes/Base2Tone_EarthDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#3f3a37",
     "statusBarItem.prominentHoverBackground": "#3f3a37",
     "statusBarItem.activeBackground": "#796b63",
-    "statusBarItem.hoverBackground": "#796b63",
+    "statusBarItem.hoverBackground": "#3f3a37",
     "titleBar.activeBackground": "#322d29",
     "titleBar.activeForeground": "#dfb99f",
     "titleBar.inactiveBackground": "#24211e",

--- a/themes/Base2Tone_EveningDark-color-theme.json
+++ b/themes/Base2Tone_EveningDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#363342",
     "statusBarItem.prominentHoverBackground": "#363342",
     "statusBarItem.activeBackground": "#787391",
-    "statusBarItem.hoverBackground": "#787391",
+    "statusBarItem.hoverBackground": "#363342",
     "titleBar.activeBackground": "#2a2734",
     "titleBar.activeForeground": "#d9d2fe",
     "titleBar.inactiveBackground": "#1f1e25",

--- a/themes/Base2Tone_FieldDark-color-theme.json
+++ b/themes/Base2Tone_FieldDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#242e2c",
     "statusBarItem.prominentHoverBackground": "#242e2c",
     "statusBarItem.activeBackground": "#667a77",
-    "statusBarItem.hoverBackground": "#667a77",
+    "statusBarItem.hoverBackground": "#242e2c",
     "titleBar.activeBackground": "#18201e",
     "titleBar.activeForeground": "#88f2e0",
     "titleBar.inactiveBackground": "#0e1110",

--- a/themes/Base2Tone_ForestDark-color-theme.json
+++ b/themes/Base2Tone_ForestDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#353b35",
     "statusBarItem.prominentHoverBackground": "#353b35",
     "statusBarItem.activeBackground": "#5e6e5e",
-    "statusBarItem.hoverBackground": "#5e6e5e",
+    "statusBarItem.hoverBackground": "#353b35",
     "titleBar.activeBackground": "#2a2d2a",
     "titleBar.activeForeground": "#c8e4c8",
     "titleBar.inactiveBackground": "#1e1f1e",

--- a/themes/Base2Tone_GardenDark-color-theme.json
+++ b/themes/Base2Tone_GardenDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#2b2c2a",
     "statusBarItem.prominentHoverBackground": "#2b2c2a",
     "statusBarItem.activeBackground": "#696d69",
-    "statusBarItem.hoverBackground": "#696d69",
+    "statusBarItem.hoverBackground": "#2b2c2a",
     "titleBar.activeBackground": "#1e1f1e",
     "titleBar.activeForeground": "#b7e3b5",
     "titleBar.inactiveBackground": "#111211",

--- a/themes/Base2Tone_HeathDark-color-theme.json
+++ b/themes/Base2Tone_HeathDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#2f2d2f",
     "statusBarItem.prominentHoverBackground": "#2f2d2f",
     "statusBarItem.activeBackground": "#6f6b70",
-    "statusBarItem.hoverBackground": "#6f6b70",
+    "statusBarItem.hoverBackground": "#2f2d2f",
     "titleBar.activeBackground": "#222022",
     "titleBar.activeForeground": "#eaa8f0",
     "titleBar.inactiveBackground": "#151415",

--- a/themes/Base2Tone_LakeDark-color-theme.json
+++ b/themes/Base2Tone_LakeDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#223c44",
     "statusBarItem.prominentHoverBackground": "#223c44",
     "statusBarItem.activeBackground": "#467686",
-    "statusBarItem.hoverBackground": "#467686",
+    "statusBarItem.hoverBackground": "#223c44",
     "titleBar.activeBackground": "#192d34",
     "titleBar.activeForeground": "#a5d8e9",
     "titleBar.inactiveBackground": "#121d21",

--- a/themes/Base2Tone_LavenderDark-color-theme.json
+++ b/themes/Base2Tone_LavenderDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#2c2839",
     "statusBarItem.prominentHoverBackground": "#2c2839",
     "statusBarItem.activeBackground": "#6e658b",
-    "statusBarItem.hoverBackground": "#6e658b",
+    "statusBarItem.hoverBackground": "#2c2839",
     "titleBar.activeBackground": "#201d2a",
     "titleBar.activeForeground": "#dcd2fe",
     "titleBar.inactiveBackground": "#15141a",

--- a/themes/Base2Tone_MallDark-color-theme.json
+++ b/themes/Base2Tone_MallDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#2b2b2c",
     "statusBarItem.prominentHoverBackground": "#2b2b2c",
     "statusBarItem.activeBackground": "#6a686e",
-    "statusBarItem.hoverBackground": "#6a686e",
+    "statusBarItem.hoverBackground": "#2b2b2c",
     "titleBar.activeBackground": "#1e1e1f",
     "titleBar.activeForeground": "#e5dbff",
     "titleBar.inactiveBackground": "#111112",

--- a/themes/Base2Tone_MeadowDark-color-theme.json
+++ b/themes/Base2Tone_MeadowDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#223644",
     "statusBarItem.prominentHoverBackground": "#223644",
     "statusBarItem.activeBackground": "#466b86",
-    "statusBarItem.hoverBackground": "#466b86",
+    "statusBarItem.hoverBackground": "#223644",
     "titleBar.activeBackground": "#192834",
     "titleBar.activeForeground": "#afddfe",
     "titleBar.inactiveBackground": "#121a21",

--- a/themes/Base2Tone_MorningDark-color-theme.json
+++ b/themes/Base2Tone_MorningDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#31363f",
     "statusBarItem.prominentHoverBackground": "#31363f",
     "statusBarItem.activeBackground": "#707a8f",
-    "statusBarItem.hoverBackground": "#707a8f",
+    "statusBarItem.hoverBackground": "#31363f",
     "titleBar.activeBackground": "#232834",
     "titleBar.activeForeground": "#b7c9eb",
     "titleBar.inactiveBackground": "#191d24",

--- a/themes/Base2Tone_MotelDark-color-theme.json
+++ b/themes/Base2Tone_MotelDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#373434",
     "statusBarItem.prominentHoverBackground": "#373434",
     "statusBarItem.activeBackground": "#86797b",
-    "statusBarItem.hoverBackground": "#86797b",
+    "statusBarItem.hoverBackground": "#373434",
     "titleBar.activeBackground": "#242323",
     "titleBar.activeForeground": "#dec9cc",
     "titleBar.inactiveBackground": "#171717",

--- a/themes/Base2Tone_PoolDark-color-theme.json
+++ b/themes/Base2Tone_PoolDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#372f42",
     "statusBarItem.prominentHoverBackground": "#372f42",
     "statusBarItem.activeBackground": "#706383",
-    "statusBarItem.hoverBackground": "#706383",
+    "statusBarItem.hoverBackground": "#372f42",
     "titleBar.activeBackground": "#2a2433",
     "titleBar.activeForeground": "#e4d2fe",
     "titleBar.inactiveBackground": "#1e1b22",

--- a/themes/Base2Tone_PorchDark-color-theme.json
+++ b/themes/Base2Tone_PorchDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#302a32",
     "statusBarItem.prominentHoverBackground": "#302a32",
     "statusBarItem.activeBackground": "#716774",
-    "statusBarItem.hoverBackground": "#716774",
+    "statusBarItem.hoverBackground": "#302a32",
     "titleBar.activeBackground": "#221e24",
     "titleBar.activeForeground": "#dfcbe6",
     "titleBar.inactiveBackground": "#151316",

--- a/themes/Base2Tone_SeaDark-color-theme.json
+++ b/themes/Base2Tone_SeaDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#27323f",
     "statusBarItem.prominentHoverBackground": "#27323f",
     "statusBarItem.activeBackground": "#738191",
-    "statusBarItem.hoverBackground": "#738191",
+    "statusBarItem.hoverBackground": "#27323f",
     "titleBar.activeBackground": "#1d262f",
     "titleBar.activeForeground": "#afd4fe",
     "titleBar.inactiveBackground": "#14191f",

--- a/themes/Base2Tone_SpaceDark-color-theme.json
+++ b/themes/Base2Tone_SpaceDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#333342",
     "statusBarItem.prominentHoverBackground": "#333342",
     "statusBarItem.activeBackground": "#737391",
-    "statusBarItem.hoverBackground": "#737391",
+    "statusBarItem.hoverBackground": "#333342",
     "titleBar.activeBackground": "#24242e",
     "titleBar.activeForeground": "#cecee3",
     "titleBar.inactiveBackground": "#1a1a1f",

--- a/themes/Base2Tone_SuburbDark-color-theme.json
+++ b/themes/Base2Tone_SuburbDark-color-theme.json
@@ -2557,7 +2557,7 @@
     "statusBarItem.prominentBackground": "#292c3d",
     "statusBarItem.prominentHoverBackground": "#292c3d",
     "statusBarItem.activeBackground": "#5b6080",
-    "statusBarItem.hoverBackground": "#5b6080",
+    "statusBarItem.hoverBackground": "#292c3d",
     "titleBar.activeBackground": "#1e202f",
     "titleBar.activeForeground": "#d2d8fe",
     "titleBar.inactiveBackground": "#15161e",


### PR DESCRIPTION
Background and foreground color is equal when you hover items in the status bar (the bottom bar) in dark themes. I adjusted the background color to make it readable.

![before-after](https://user-images.githubusercontent.com/2291639/147664320-daead2c8-eaa1-451c-9280-d1c65711c026.jpg)
